### PR TITLE
refactor(api): dynamic import db in advocates and seed routes; disabl…

### DIFF
--- a/src/app/api/advocates/searchHelpers.ts
+++ b/src/app/api/advocates/searchHelpers.ts
@@ -38,12 +38,14 @@ export function filterAdvocatesMock(data: Advocate[], search: string): Advocate[
  * Applies specialty filtering to a Drizzle ORM query via JSONB contains operations.
  * The query must support a .where() method that returns the same query type.
  */
-export function applySpecialtyFilter<
-  Q extends { where(condition: unknown): Q }
->(
-  query: Q,
+/**
+ * Applies specialty filtering to a Drizzle ORM query via JSONB contains operations.
+ * Accepts any query builder and returns the updated query.
+ */
+export function applySpecialtyFilter(
+  query: any,
   specialties: string[]
-): Q {
+): any {
   if (specialties.length === 0) {
     return query;
   }
@@ -53,8 +55,8 @@ export function applySpecialtyFilter<
       sql`${advocates.specialties} @> ${JSON.stringify([spec])}::jsonb`
     )
     .reduce((acc, cond) => sql`${acc} OR ${cond}`);
-  // Apply the OR condition
-  return query.where(condition);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (query as any).where(condition);
 }
 /**
  * Filters an in-memory array of Advocate objects by specialties.

--- a/src/app/api/seed/route.ts
+++ b/src/app/api/seed/route.ts
@@ -1,8 +1,13 @@
-import db from "../../../db";
+// import db dynamically inside handler to avoid build-time initialization
+// import db from "../../../db";
+// Disable prerendering to avoid build-time DB initialization
+export const dynamic = 'force-dynamic';
 import { advocates } from "../../../db/schema";
 import { advocateData } from "../../../db/seed/advocates";
 
 export async function POST() {
+  // Dynamically import db to avoid import-time errors
+  const { default: db } = await import("../../../db");
   const records = await db.insert(advocates).values(advocateData).returning();
 
   return Response.json({ advocates: records });


### PR DESCRIPTION
…e prerendering; relax applySpecialtyFilter types

## Summary by Sourcery

Dynamically import the database connection in API routes to prevent initialization during build time.

Enhancements:
- Refactor advocate query building logic for better readability.
- Loosen type restrictions for the `applySpecialtyFilter` utility function to use `any` type.
- Dynamically import database connection in `/api/advocates` and `/api/seed` routes.